### PR TITLE
Fixing sh-utter to sh_utter to in order to run

### DIFF
--- a/af/sparrowhawk/af_sparrowhawk.sh
+++ b/af/sparrowhawk/af_sparrowhawk.sh
@@ -8,7 +8,7 @@ LANG=af
 
 # Tools:
 runfiles="${0}.runfiles"
-sh_utter="$runfiles/language_resources/utils/sh-utter"
+sh_utter="$runfiles/language_resources/utils/sh_utter"
 prefix=`pwd`/"$runfiles"/language_resources/"$LANG"/sparrowhawk/
 config=sparrowhawk_configuration.ascii_proto
 


### PR DESCRIPTION
When running this, af_textnorm compains that it is not able to find sh-utter, as it doesn't exist.

The correct path is sh_utter.